### PR TITLE
fix(flow): Remove operation ID HTTP header

### DIFF
--- a/src/FlowPair/Flow/Infrastructure/FlowHttpClient.cs
+++ b/src/FlowPair/Flow/Infrastructure/FlowHttpClient.cs
@@ -11,7 +11,6 @@ public sealed class FlowHttpClient : HttpClient
     {
         BaseAddress = new Uri(FlowBaseAddress);
         DefaultRequestHeaders.Add("FlowAgent", "flow-pair");
-        DefaultRequestHeaders.Add("FlowOperationId", Guid.NewGuid().ToString("N"));
         DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to FlowPair!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Parallel chat threads leaking information with each other

## Details on the issue fix or feature implementation
- Remove the HTTP header `FlowOperationId`

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
