### PR TITLE
ci: Allow GitHub API access for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             aka.ms:443
+            api.github.com:443
             api.nuget.org:443
             dotnetbuilds.azureedge.net:443
             dotnetcli.azureedge.net:443


### PR DESCRIPTION
<!-- Thank you for contributing to FlowPair!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Publish failing because blocked access to GitHub API

## Details on the issue fix or feature implementation
- Allow GitHub API access for publishing

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
