### PR TITLE
ci: Downgrade action-gh-release to 2.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,7 @@ jobs:
           merge-multiple: true
 
       - name: 🚀 Publish
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: "flowpair*.zip"


### PR DESCRIPTION
<!-- Thank you for contributing to FlowPair!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- softprops/action-gh-release#555

## Details on the issue fix or feature implementation
- Downgrade action-gh-release to version 2.1.0

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
